### PR TITLE
feat: use different backdrop index for movie genres

### DIFF
--- a/src/components/Discover/MovieGenreList/index.tsx
+++ b/src/components/Discover/MovieGenreList/index.tsx
@@ -39,7 +39,7 @@ const MovieGenreList = () => {
               name={genre.name}
               image={`https://image.tmdb.org/t/p/w1280_filter(duotone,${
                 genreColorMap[genre.id] ?? genreColorMap[0]
-              })${genre.backdrops[4]}`}
+              })${genre.backdrops[5]}`}
               url={`/discover/movies/genre/${genre.id}`}
               canExpand
             />

--- a/src/components/Discover/MovieGenreSlider/index.tsx
+++ b/src/components/Discover/MovieGenreSlider/index.tsx
@@ -42,7 +42,7 @@ const MovieGenreSlider = () => {
             name={genre.name}
             image={`https://image.tmdb.org/t/p/w1280_filter(duotone,${
               genreColorMap[genre.id] ?? genreColorMap[0]
-            })${genre.backdrops[4]}`}
+            })${genre.backdrops[5]}`}
             url={`/discover/movies?genre=${genre.id}`}
           />
         ))}


### PR DESCRIPTION
#### Description

The romance category image with the index of 4 was NSFW so this changes that index to 5. It doesn't look like there is a great way to do this via the TMDB API

#### Screenshot (if UI-related)

#### To-Dos

- [ ] Successful build `yarn build`
- [ ] Translation keys `yarn i18n:extract`
- [ ] Database migration (if required)

#### Issues Fixed or Closed

- Fixes #XXXX
